### PR TITLE
Increased grid width, and different symbol colours for both players

### DIFF
--- a/BIT504_Assessment2/src/Board.java
+++ b/BIT504_Assessment2/src/Board.java
@@ -2,7 +2,7 @@ import java.awt.*;
 
 public class Board {
 // grid line width
-	public static final int GRID_WIDTH = 8;
+	public static final int GRID_WIDTH = 12;
 	// grid line half width
 	public static final int GRID_WIDTH_HALF = GRID_WIDTH / 2;
 

--- a/BIT504_Assessment2/src/Cell.java
+++ b/BIT504_Assessment2/src/Cell.java
@@ -31,13 +31,13 @@ public class Cell {
 		int x1 = col * GameMain.CELL_SIZE + GameMain.CELL_PADDING;
 		int y1 = row * GameMain.CELL_SIZE + GameMain.CELL_PADDING;
 		if (content == Player.Cross) {
-			graphic2D.setColor(Color.RED);
+			graphic2D.setColor(Color.GREEN);
 			int x2 = (col + 1) * GameMain.CELL_SIZE - GameMain.CELL_PADDING;
 			int y2 = (row + 1) * GameMain.CELL_SIZE - GameMain.CELL_PADDING;
 			graphic2D.drawLine(x1, y1, x2, y2);
 			graphic2D.drawLine(x2, y1, x1, y2);
 		} else if (content == Player.Nought) {
-			graphic2D.setColor(Color.BLUE);
+			graphic2D.setColor(Color.ORANGE);
 			graphic2D.drawOval(x1, y1, GameMain.SYMBOL_SIZE, GameMain.SYMBOL_SIZE);
 		}
 	}


### PR DESCRIPTION
## What?
I've updated some visual elements, including:
- increased grid width from 8 to 12
- the colour of symbol Cross was changed to green from red
- the colour of symbol Nought was changed to orange from blue
## Why?
These changes are to provide a better visual experience for the players with the increased cell size and dark background colour.
## How?
The change of grid width was made in the Board class, and the change of symbol colours was made in the Cell class.
## Testing?
I've played the game a few times with the updated visual elements. The outcomes were desired and no error occurred.